### PR TITLE
Fixing windows commands in docs

### DIFF
--- a/content/lua.scripts.manual/installation.md
+++ b/content/lua.scripts.manual/installation.md
@@ -60,9 +60,9 @@ The recommended way to enable and disable specific scripts is using the script m
 
     echo 'require "tools/script_manager"' > ~/.config/darktable/luarc
 
-### Windows
+### Windows ( via command prompt )
 
-    echo "require 'tools/script_manager'" > %LOCALAPPDATA%\darktable\luarc
+    echo require 'tools/script_manager' > %LOCALAPPDATA%\darktable\luarc
 
 ### Snap
 

--- a/content/lua.scripts.manual/troubleshooting.md
+++ b/content/lua.scripts.manual/troubleshooting.md
@@ -22,4 +22,4 @@ Open a terminal and start darktable with the command `/Applications/darktable.ap
 
 ### Windows
 
-Open a command prompt. Start darktable with the command "C:\Program Files\darktable\bin\darktable" -d lua > log.txt. This provides debugging information to give you insight into what is happening.
+Open a command prompt. Start darktable with the command `"C:\Program Files\darktable\bin\darktable" -d lua > log.txt 2> log_err.txt`. `stdout`, which contains regular output of commands like `print()` will get printed into the `log.txt` file. `stderr`, which contains program errors will get saved inside `log_err.txt` file. This provides debugging information to give you insight into what is happening.

--- a/content/lua.scripts.manual/troubleshooting.md
+++ b/content/lua.scripts.manual/troubleshooting.md
@@ -22,4 +22,4 @@ Open a terminal and start darktable with the command `/Applications/darktable.ap
 
 ### Windows
 
-Open a command prompt. Start darktable with the command `"C:\Program Files\darktable\bin\darktable" -d lua > log.txt 2> log_err.txt`. `stdout`, which contains regular output of commands like `print()` will get printed into the `log.txt` file. `stderr`, which contains program errors will get saved inside `log_err.txt` file. This provides debugging information to give you insight into what is happening.
+Open a command prompt. Start darktable with the command `"C:\Program Files\darktable\bin\darktable" -d lua > log.txt 2>&1`. This provides debugging information to give you insight into what is happening.


### PR DESCRIPTION
### inside troubleshooting.md
Added `2> log_err.txt` to the command and explained what it does. This is necessary as stderr will otherwise get outputted to the console instead of the `log.txt` file.

### inside installation.md
The command `echo "require 'tools/script_manager'" > %LOCALAPPDATA%\darktable\luarc` would push 
```lua
"require 'tools/script_manager'"
```
instead of
```lua
require 'tools/script_manager'
```
to the file. So I removed the `"` around echoing statement, as they're not necessary.