### PR TITLE
Clarify darktable.configuration.cache_dir purpose

### DIFF
--- a/content/lua.api.manual/darktable/darktable.configuration.md
+++ b/content/lua.api.manual/darktable/darktable.configuration.md
@@ -44,7 +44,7 @@ The name of the directory where darktable will find its global configuration obj
 
 `string`
 
-The name of the directory where darktable will store its mipmaps.
+The name of the directory where darktable caches objects.
 
 # darktable.configuration.api_version_major
 


### PR DESCRIPTION
Changed darktable.configuation.cache_dir to clarify that not just mipmaps are stored there.